### PR TITLE
[fix, style] 로그아웃 버튼 누를 시 새로고침 후 데이터 리패칭, 유저 role에 따른 부분 랜더링 코드 추가

### DIFF
--- a/apps/client/app/page.tsx
+++ b/apps/client/app/page.tsx
@@ -4,7 +4,7 @@ import TopCarousel from '../components/home/TopCarousel';
 import BottomCarousel from '../components/home/BottomCarousel';
 import { TopData } from '../components/home/dummy';
 import { BottomData } from '../components/home/dummy';
-import { Footer, Top, TopSuspense } from 'ui';
+import { Footer, Top } from 'ui';
 import HomeNearPets from '../components/home/homeNearPets';
 import HomeVolunteerPoster from '../components/home/homeVolunteerPoster';
 import { useEffect, useState } from 'react';
@@ -13,7 +13,6 @@ import HomeNearNews from '../components/home/homeNearNews';
 
 export default function Page() {
   const [isLogin, setIsLogin] = useState<boolean>();
-
   useEffect(() => {
     const cookies = new Cookies();
     if (cookies.get('sb-ztcvdzkqqrglziiavupe-auth-token')) {
@@ -25,16 +24,12 @@ export default function Page() {
 
   return (
     <>
-      {typeof isLogin !== 'undefined' ? (
-        <Top isLogin={isLogin} />
-      ) : (
-        <TopSuspense />
-      )}
+      <Top />
+      {/* <TopSuspense /> */}
+      {/* {typeof isLogin !== 'undefined' ? <Top /> : <TopSuspense />} */}
       <main className='w-full flex flex-col gap-[7.5rem] mobile:gap-[7.5rem] tablet:gap-[11.25rem] desktop:gap-60'>
         <TopCarousel slides={TopData} />
-        {typeof isLogin !== 'undefined' ? (
-          <HomeNearPets isLogin={isLogin} />
-        ) : null}
+        <HomeNearPets />
         <BottomCarousel slides={BottomData} />
         {typeof isLogin !== 'undefined' ? (
           isLogin ? (

--- a/apps/client/app/profile/page.tsx
+++ b/apps/client/app/profile/page.tsx
@@ -1,35 +1,41 @@
 'use client';
 
-import { Cookies } from '@near/react-cookie';
 import { useState, useEffect } from 'react';
 import { Footer, Top, TopSuspense } from 'ui';
 import BottomButtonsSection from '../../components/profile/BottomButtons';
 import { useRouter } from 'next/navigation';
 import ProfileBoxSection from '../../components/profile/ProfileBoxSection';
 import CardsSection from '../../components/profile/CardsSection';
+import { Session, createClientComponentClient } from '@near/supabase';
 
 export default function ProfilePage() {
-  const [isLogin, setIsLogin] = useState<boolean>();
   const router = useRouter();
+  const supabase = createClientComponentClient();
+  const [userSession, setuserSession] = useState<Session | null>();
+
+  async function getUserSession() {
+    const { data, error } = await supabase.auth.getSession();
+    if (data) {
+      setuserSession(data.session);
+    }
+    if (error) {
+      console.log(error);
+    }
+  }
+
+  if (userSession === null) {
+    router.push('/');
+  }
 
   useEffect(() => {
-    const cookies = new Cookies();
-    if (cookies.get('sb-ztcvdzkqqrglziiavupe-auth-token')) {
-      setIsLogin(true);
-    } else {
-      setIsLogin(false);
-      router.push('/');
-    }
+    getUserSession();
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
     <>
-      {typeof isLogin !== 'undefined' ? (
-        <Top isLogin={isLogin} />
-      ) : (
-        <TopSuspense />
-      )}
+      {userSession ? <Top /> : <TopSuspense />}
       <main className='flex flex-col gap-[7.5rem] mobile:gap-[7.5rem] tablet:pt-[6.5625rem] tablet:gap-[11.5625rem] desktop:pt-[8.125rem] desktop:gap-[20.0625rem]'>
         <section className='flex flex-col gap-[7.5rem] justify-center items-center mobile:flex-col tablet:flex-col desktop:flex-row'>
           <ProfileBoxSection />

--- a/apps/client/app/profile/pet/page.tsx
+++ b/apps/client/app/profile/pet/page.tsx
@@ -6,7 +6,7 @@ import { ButtonXL } from 'ui/components/buttons/Button';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 import FooterShadowBox from 'ui/components/footer/FooterShadowBox';
 import RadioTag from 'ui/components/tags/RadioTag';
-import { supabase } from '@near/supabase';
+import { Session, supabase } from '@near/supabase';
 import { useRouter } from 'next/navigation';
 
 // interface Props {
@@ -25,8 +25,10 @@ interface UserPetType {
 
 function UserPetProfilePage() {
   const router = useRouter();
-  const [userId, setUserId] = useState<string | null>(null);
+  const [userSession, setuserSession] = useState<Session | null>();
+
   const supabaseAuth = createClientComponentClient();
+
   const {
     control,
     handleSubmit,
@@ -46,8 +48,8 @@ function UserPetProfilePage() {
     const fetchSession = async () => {
       try {
         const { data } = await supabaseAuth.auth.getSession();
-        if (data && data.session) {
-          setUserId(data.session.user.id);
+        if (data) {
+          setuserSession(data.session);
         }
       } catch (error) {
         console.error('실패', error);
@@ -55,13 +57,17 @@ function UserPetProfilePage() {
     };
 
     fetchSession();
+
+    if (!userSession) {
+      router.push('/');
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onSubmit = async (formData) => {
     const petProfileData = {
       ...formData,
-      id: userId,
+      id: userSession?.user.id,
     };
     const { error } = await supabase
       .from('user_pet_profile')

--- a/packages/ui/components/top/Top.tsx
+++ b/packages/ui/components/top/Top.tsx
@@ -6,7 +6,6 @@ import TopMenuBar from './topMenuBar/TopMenuBar';
 import HamburgerMenu from './hamburgerMenu/HamburgerMenu';
 
 interface TopProps {
-  isLogin: boolean;
   backgroundColor?: 'white' | 'transparent';
   hasBoxShadow?: boolean;
   handleSignOut?: () => void;

--- a/packages/ui/components/top/hamburgerMenu/HamburgerMenu.tsx
+++ b/packages/ui/components/top/hamburgerMenu/HamburgerMenu.tsx
@@ -1,10 +1,11 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 'use client';
 
 import HamburgerMenuTabs from './HamburgerMenuTabs';
 import { MenuOptionTabsContent } from '../MenuOptionTabsContent';
 import { Session, createClientComponentClient } from '@near/supabase';
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+
 interface HamburgerMenuProps {
   setIsHamburgerMenuVisible: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -29,7 +30,6 @@ interface HamburgerMenuProps {
 function HamburgerMenu({ setIsHamburgerMenuVisible }: HamburgerMenuProps) {
   const supabase = createClientComponentClient();
   const [userSession, setuserSession] = useState<Session | null>();
-  const router = useRouter();
 
   async function getUserSession() {
     const { data, error } = await supabase.auth.getSession();
@@ -48,8 +48,8 @@ function HamburgerMenu({ setIsHamburgerMenuVisible }: HamburgerMenuProps) {
 
   async function handleSignOut() {
     await supabase.auth.signOut();
-    router.refresh();
     setIsHamburgerMenuVisible(false);
+    if (typeof window !== 'undefined') window.location.reload();
   }
 
   return (
@@ -84,7 +84,7 @@ function HamburgerMenu({ setIsHamburgerMenuVisible }: HamburgerMenuProps) {
               프로필
             </HamburgerMenuTabs>
             <div className='bg-black w-[0.0625rem] h-[1.25rem]' />
-            <HamburgerMenuTabs size='sm' href='/' onClick={handleSignOut}>
+            <HamburgerMenuTabs size='sm' href={'/'} onClick={handleSignOut}>
               로그아웃
             </HamburgerMenuTabs>
           </>

--- a/packages/ui/components/top/topMenuBar/TopMenuBarIcons.tsx
+++ b/packages/ui/components/top/topMenuBar/TopMenuBarIcons.tsx
@@ -7,7 +7,7 @@ import { MenuOptionTabsContent } from '../MenuOptionTabsContent';
 import TopMenuTabs from './TopMenuTabs';
 import { Session, createClientComponentClient } from '@near/supabase';
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+
 export interface TopMenuBarIconsProps {
   setIsHamburgerMenuVisible: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -15,7 +15,7 @@ export interface TopMenuBarIconsProps {
 function TopMenuBarIcons({ setIsHamburgerMenuVisible }: TopMenuBarIconsProps) {
   const supabase = createClientComponentClient();
   const [userSession, setuserSession] = useState<Session | null>();
-  const router = useRouter();
+  // const router = useRouter();
   async function getUserSession() {
     const { data, error } = await supabase.auth.getSession();
     if (data) {
@@ -28,7 +28,7 @@ function TopMenuBarIcons({ setIsHamburgerMenuVisible }: TopMenuBarIconsProps) {
 
   async function handleSignOut() {
     await supabase.auth.signOut();
-    router.refresh();
+    if (typeof window !== 'undefined') window.location.reload();
   }
   useEffect(() => {
     getUserSession();
@@ -73,6 +73,7 @@ function TopMenuBarIcons({ setIsHamburgerMenuVisible }: TopMenuBarIconsProps) {
               className='mobile:text-sm tablet:text-sm desktop:text-lg text-text-black1'
               href={'/'}
               onClick={handleSignOut}
+              replace
             >
               로그아웃
             </Link>


### PR DESCRIPTION
[수정 사항]
- **알림 : @syssys131 코드를 급하게 수정한 터라 미흡한 면이 있을 수 있습니다.**
- boolean으로 login여부를 따지는게 아닌 getSession으로 유저정보를 받아와 있는지 여부에 따라 부분 랜더링 처리했습니다.
- 홈 화면의 'ㅇㅇㅇ 님 근처...' 부분을 로그인 된 유저의 이름을 추출해 랜더링 시켰습니다. 보호소 유저용 UI는 없어서 일단 이 또한 롤에 따라 data fetch하는 api를 다르게해서 이름을 넣어놨습니다.
- NextLink는 a링크와 다르게 새로고침이 되지않습니다. 그래서 유저가 새로고침을 하지 않음면 리랜더링이 일어나지 않는 구조라, 강제로 새로고침하는 코드를 넣어놨습니다.
- profile, petprofile, home 등 routing여부를 session을 가져온 값으로 분기처리했습니다.